### PR TITLE
auth情報からgithubアカウント画像を取得、userに保存

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-class SessionsController < ApplicationController
-  def index
-  end
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,14 +33,15 @@ class User < ApplicationRecord
 
   def self.find_for_github_oauth(auth, signed_in_resource = nil)
     user = User.find_by(provider: auth.provider, uid: auth.uid)
-
     unless user
-      user = User.new(provider: auth.provider,
-                      uid:      auth.uid,
-                      name:     auth.info.name,
-                      email:    auth.info.email,
-                      password: Devise.friendly_token[0, 20],
-                      confirmed_at: Time.zone.now
+      user = User.new(
+        provider:     auth.provider,
+        uid:          auth.uid,
+        name:         auth.info.name,
+        email:        auth.info.email,
+        avatar_url:   auth.info.image,
+        password:     Devise.friendly_token[0, 20],
+        confirmed_at: Time.zone.now
       )
     end
     user.save

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,11 +5,6 @@ Rails.application.routes.draw do
   }
   # 後ほど変更
   root :to => 'posts#index'
-  # root 'sessions#test'
-  # ログイン機能実装後削除
-  post '/login_dev', to: 'sessions#login_dev'
-
-  delete '/logout', to: 'sessions#destroy'
 
   resources :posts, only: %i(new create edit update show index) do
     resources :messages, only: %i(index create)

--- a/db/migrate/20190224073550_add_column_to_users.rb
+++ b/db/migrate/20190224073550_add_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddColumnToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :avatar_url, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_22_031603) do
+ActiveRecord::Schema.define(version: 2019_02_24_073550) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 2019_02_22_031603) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "avatar_url", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## Issue番号
173

## 予定時間/実績時間
30~60m

## What - なにを修正したか？
- userテーブルに画像URL用のカラムを追加
- userインスタンス作成時に画像URLを保存

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## Why - なぜ修正したか？
アカウント画像を表示するため

<!-- 変更の目的 -->

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
