### PR TITLE
post投稿/編集フォームの不具合修正

### DIFF
--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -1,12 +1,19 @@
 .container
   = form_with(model: post, local: true) do |f|
+    - if @post.errors.any?
+      #error_messages
+        ul
+          - @post.errors.full_messages.each do |msg|
+            li
+              = msg
     .field
       = f.label :リポジトリ, class: 'label'
-      - if params[:action] == 'new'
+      - if @post.repository.blank?
         = f.text_field :repository, class: 'control input'
         p.help
           | 募集するリポジトリのURLを入力してください
-      = f.text_field :repository, class: 'control input', disabled: true if params[:action] == 'edit'
+      - else
+        = f.text_field :repository, class: 'control input', disabled: true
     .field
       = f.label :募集タイトル, class: 'label'
       = f.text_field :title, class: 'control input'

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -1,0 +1,9 @@
+ja:
+  activerecord:
+    models:
+      post: "プロジェクト"
+    attributes:
+      post:
+        title: "タイトル"
+        content: "募集内容"
+        repository: "リポジトリ"


### PR DESCRIPTION
## Issue番号
#246 
前の担当箇所を触ってて不具合あったので直しましたー

## 予定時間/実績時間
30m

## What - なにを修正したか？
- `posts/_form.html.slim`のリポジトリformの切り替え表示をactionに依存して行なっていたため、post.repositoryの中身があるかどうかで判別するコードに修正。
→ 例えばnewをform未入力で投稿した場合にformが現れないという事象が発生したから。

- バリデーションエラーのメッセージ表示追加。
- バリデーションエラーメッセージ日本語化。

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->


<!-- 変更の目的 -->

## 補足

→ postをプロジェクトと表示するようにしてるけどOK? 異論あればご意見ください〜
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
