### PR TITLE
プロジェクト投稿 Updateすると落ちる

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -32,7 +32,9 @@ class Post < ApplicationRecord
 
   def format_repository
     url_splits = self.repository.split("/")
-    self.owner = url_splits[-2]
-    self.repository = url_splits[-1]
+    if !url_splits[-2].nil? # 仮対応
+      self.owner = url_splits[-2]
+      self.repository = url_splits[-1]
+    end
   end
 end


### PR DESCRIPTION
## Issue番号
#251 

## 予定時間/実績時間
0.5h / 5.0h

## What - なにを修正したか？
更新登録時にエラーにさせない。
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
更新前
![2019-03-01 5 04 38](https://user-images.githubusercontent.com/40923242/53595080-ab591a80-3bdf-11e9-9acf-f8dbf741d706.png)
内容を編集
![2019-03-01 5 05 09](https://user-images.githubusercontent.com/40923242/53595093-b1e79200-3bdf-11e9-9f2f-0f67e8590bc8.png)
編集ボタン押して更新（showへ遷移できる)
![2019-03-01 5 05 22](https://user-images.githubusercontent.com/40923242/53595130-c9bf1600-3bdf-11e9-8215-aab92b612777.png)


## Why - なぜ修正したか？
新規登録・更新登録の両方でformat_repositoryメソッド(URL解析)が実行されているが
更新登録時はリポジトリ名しか表示しないため、期待した配列結果にならない。

なので、更新登録時はownerとrepositoryをupdateさせないように制御を追加した。
<!-- 変更の目的 -->

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
