### PR TITLE
募集終了機能の追加 index

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -91,5 +91,6 @@ class PostsController < ApplicationController
         message = "【募集終了】"
       else
       end
+      message
     end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -74,10 +74,22 @@ class PostsController < ApplicationController
           "language" => client.language,
           "topics" => client.topics.names,
           "description" => client.description,
-          "stargazers_count" => client.stargazers_count
+          "stargazers_count" => client.stargazers_count,
+          "status" => convert_japanese(repo.status)
         }
         posts.push(post)
       end
       posts
+    end
+
+    def convert_japanese(status)
+      message = ""
+      case status
+      when "wanted"
+        message = "【募集中】"
+      when "stopped"
+        message = "【募集終了】"
+      else
+      end
     end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -75,22 +75,10 @@ class PostsController < ApplicationController
           "topics" => client.topics.names,
           "description" => client.description,
           "stargazers_count" => client.stargazers_count,
-          "status" => convert_japanese(repo.status)
+          "status" => view_context.get_status_name(repo.status)
         }
         posts.push(post)
       end
       posts
-    end
-
-    def convert_japanese(status)
-      message = ""
-      case status
-      when "wanted"
-        message = "【募集中】"
-      when "stopped"
-        message = "【募集終了】"
-      else
-      end
-      message
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,15 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def get_status_name(status)
+    message = ""
+    case status
+    when "wanted"
+      message = "【募集中】"
+    when "stopped"
+      message = "【募集終了】"
+    else
+    end
+    message
+  end
 end

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -11,13 +11,21 @@
             span.tag.is-normal タグ
             span.tag.is-warning.is-normal = "{{ topic }}"
       .content.is-medium v-if="repo.description" 簡易説明文： {{ repo.description }}
-      .content.is-small
-      .tags.has-addons
-        span.tag
-          i.fa.fa-star
-        span.tag.is-primary = "{{ repo.stargazers_count }}"
-      .content.is-normal
-        u VIEW PROJECT
+      table style="width:100%"
+        tr
+          td
+            .content.is-small
+              .tags.has-addons
+                span.tag
+                  i.fa.fa-star
+                span.tag.is-primary = "{{ repo.stargazers_count }}"
+          td.status-area rowspan="2"
+            span.status 【募集終了】
+        tr
+          td 
+            .content.is-normal
+            u VIEW PROJECT
+          td
 / - if user_signed_in?→footerとぶつかるまたheaderに投稿があるためコメントアウト
 /   .div.footer-btn
 /     a.button.is-dark href="/posts/new" プロジェクト新規登録
@@ -45,4 +53,11 @@ css:
   }
   .footer-btn:hover {
     opacity: 0.85;
+  }
+  .status-area {
+    text-align: right;
+    vertical-align: bottom;
+  }
+  .status {
+    font-size: 1.5em;
   }

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -20,7 +20,7 @@
                   i.fa.fa-star
                 span.tag.is-primary = "{{ repo.stargazers_count }}"
           td.status-area rowspan="2"
-            span.status 【募集終了】
+            span.status = "{{ repo.status }}"
         tr
           td 
             .content.is-normal


### PR DESCRIPTION
## Issue番号
#116 #259 

## 予定時間/実績時間
1.5h / 4.0h

## What - なにを修正したか？
募集のステータスを表示
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
![2019-03-02 11 13 31](https://user-images.githubusercontent.com/40923242/53675711-64048400-3cdc-11e9-9f2c-37a74cd8fa33.png)

## Why - なぜ修正したか？
募集終了機能の追加
<!-- 変更の目的 -->

## 補足
募集中状態も【募集中】と表示するようにした。
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
