### PR TITLE
募集終了・削除機能追加 show

### DIFF
--- a/app/assets/stylesheets/postsshow.css
+++ b/app/assets/stylesheets/postsshow.css
@@ -9,7 +9,11 @@ iphone max 480
 }
 
 .show-content-right-git-description {
-  padding: 12px 0 40px 0;
+  padding-top: 12px;
+}
+
+.show-content-right-git-url {
+  padding-bottom: 12px;
 }
 
 /*=========================

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PostsController < ApplicationController
-  before_action :set_post, only: %i(edit update)
+  before_action :set_post, only: %i(edit update destroy)
   before_action :only_logged_in_user, only: %i(new create edit update)
   before_action :only_author, only: %i(edit update)
 
@@ -47,7 +47,7 @@ class PostsController < ApplicationController
   end
 
   def destroy
-    if Post.find(params[:id]).delete
+    if @post.destroy
       redirect_to posts_path, notice: "投稿を削除しました"
     else
       render :show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -48,9 +48,9 @@ class PostsController < ApplicationController
 
   def destroy
     if Post.find(params[:id]).delete
-        redirect_to posts_path, notice: "投稿を削除しました"
+      redirect_to posts_path, notice: "投稿を削除しました"
     else
-        render :show
+      render :show
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -46,6 +46,14 @@ class PostsController < ApplicationController
     }
   end
 
+  def destroy
+    if Post.find(params[:id]).delete
+        redirect_to posts_path, notice: "投稿を削除しました"
+    else
+        render :show
+    end
+  end
+
   private
     def post_params
       params.require(:post).permit(:title, :content, :repository, :status)

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -59,8 +59,8 @@ section#show-comment
         - if @user == current_user
           = link_to edit_post_path(params[:id]), class: "show-button my-shadow show-button-join"
             p 編集
-          a.show-button.my-shadow.show-button-delete
+          = link_to post_path(params[:id]), class: "show-button my-shadow show-button-delete", method: :delete, data: { confirm: "本当に削除しますか" }
             p 削除
-        - else
+        - elsif @post.status == "wanted"
           a.show-button.my-shadow.show-button-join
             p 参加

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -18,7 +18,7 @@ section#show-content.columns
     .show-content-right-head
       h1.title
         p = @post.title
-        - if @post.status == "stopped"
+        - if @post.stopped?
           font color="red" 募集は終了しました
 
     .show-content-right-git-info.field.is-grouped
@@ -61,6 +61,6 @@ section#show-comment
             p 編集
           = link_to post_path(params[:id]), class: "show-button my-shadow show-button-delete", method: :delete, data: { confirm: "本当に削除しますか" }
             p 削除
-        - elsif @post.status == "wanted"
+        - elsif @post.wanted?
           a.show-button.my-shadow.show-button-join
             p 参加

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -18,7 +18,8 @@ section#show-content.columns
     .show-content-right-head
       h1.title
         p = @post.title
-        p = get_status_name(@post.status)
+        - if @post.status == "stopped"
+          font color="red" 募集は終了しました
 
     .show-content-right-git-info.field.is-grouped
       .control

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -16,7 +16,9 @@ section#show-content.columns
   //  プロジェクトの情報を表示するメイン枠
   .show-content-right.column
     .show-content-right-head
-      h1.title = @post.title
+      h1.title
+        p = @post.title
+        p = get_status_name(@post.status)
 
     .show-content-right-git-info.field.is-grouped
       .control

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -44,6 +44,9 @@ section#show-content.columns
     .show-content-right-git-description
       p = @git['description']
 
+    .show-content-right-git-url
+      = link_to "https://github.com/#{@post.owner}/#{@post.repository}"
+
     .show-content-5.box
       / p
       = simple_format(h(@post.content))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
     resources :profiles, only: %i(index update)
   end
 
-  resources :posts, only: %i(new create edit update show index) do
+  resources :posts, only: %i(new create edit update show index destroy) do
     resources :messages, only: %i(index create)
   end
 


### PR DESCRIPTION
## Issue番号
#116 
#259 

## 予定時間/実績時間
1.5h / 3.0h

## What - なにを修正したか？
① 募集状態を表示する （募集終了時のみ「募集は終了しました」という文言を表示する)
![2019-03-03 7 36 43](https://user-images.githubusercontent.com/40923242/53688431-2446a680-3d87-11e9-9047-0efe414b10b7.png)

② ログインユーザ != 起票者 AND 募集終了の投稿については「参加ボタンを表示しない」
![2019-03-03 7 23 36](https://user-images.githubusercontent.com/40923242/53688410-cfa32b80-3d86-11e9-9862-66e064850cf8.png)

- 削除処理を追加する
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
削除ボタン押下時の挙動（確認ポップアップ → 一覧画面へ遷移する)
![2019-03-03 7 31 34](https://user-images.githubusercontent.com/40923242/53688378-6cb19480-3d86-11e9-9f36-2c2a63374b0d.png)
![2019-03-03 7 31 45](https://user-images.githubusercontent.com/40923242/53688380-72a77580-3d86-11e9-95b4-29e864f26daa.png)

## Why - なぜ修正したか？
募集終了・削除機能を追加するため
<!-- 変更の目的 -->

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
