### PR TITLE
リポジトリ存在チェック等 投稿画面考慮漏れ対応

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -23,6 +23,7 @@ body {
   background-color: #f9fbfe;
   max-width: 1440px !important;
 }
+
 header {
   width: 100%;
 }
@@ -39,6 +40,7 @@ header {
   max-width: 980px;
   margin: 0 auto;
 }
+
 /* navstart */
 .my-navbar-menu {
   display: flex;
@@ -52,29 +54,35 @@ header {
   background: #ffffff;
   box-shadow: 0px 3px 4px rgba(0, 0, 0, 0.25);
 }
+
 img {
   /* margin-right: 12px; */
   border-radius: 0.2666666667em;
 }
+
 .navbar-item img {
   border-radius: 50%;
 }
+
 .avatar {
   width: 2.6em;
   height: 1.6em;
   border-radius: 0.2666666667em;
 }
+
 .meister-log {
   width: 100%;
   height: 100%;
   border-radius: 0.2666666667em;
 }
+
 a.button.is-primary {
   height: 30px;
   width: 93px;
   box-shadow: 0px 0px 4px rgba(0, 0, 0, 0.25);
   border-radius: 5px;
 }
+
 a.a.button.is-left {
   height: 30px;
   background: #ef4d4d;
@@ -83,9 +91,11 @@ a.a.button.is-left {
   color: aliceblue;
   margin-right: 5px;
 }
+
 a.button.is-left {
   margin-right: 16px;
 }
+
 .navbar-log {
   padding-top: 13px;
 }
@@ -102,21 +112,26 @@ a.button.is-left {
   background-color: #00d1b2;
   margin-right: 10px;
 }
+
 .fab2 {
   padding-left: 8px;
   padding-right: 8px;
   height: 30px;
   font-size: 15px !important;
 }
+
 .navbar-start {
   margin-left: 14%;
 }
+
 .navbar-end {
   margin-right: 12%;
 }
+
 a.btn:hover {
   color: white !important;
 }
+
 /* navbar終わり */
 .flash {
   background-color: #293742;
@@ -192,4 +207,12 @@ a.btn:hover {
 
 .error-left ul {
   margin-left: 30px;
+}
+
+/* 共通 */
+.disabled-style {
+  background-color: #f5f5f5 !important;
+  border-color: #f5f5f5 !important;
+  box-shadow: none !important;
+  color: #7a7a7a !important;
 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -24,9 +24,8 @@ class Post < ApplicationRecord
   belongs_to :user
   has_many :messages, dependent: :destroy
   validates_with PostValidator, field: [:repository, :title, :content]
-
-  before_create :format_repository
-  before_save :update_date
+ 
+  before_save :format_repository, :update_date
 
   def owner_and_repository
     [owner, repository].join("/")

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -24,7 +24,7 @@ class Post < ApplicationRecord
   belongs_to :user
   has_many :messages, dependent: :destroy
   validates_with PostValidator, field: [:repository, :title, :content]
- 
+
   before_save :format_repository, :update_date
 
   def owner_and_repository

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -25,7 +25,7 @@
         = f.text_area :content, class: 'control textarea'
       .field
         .control
-          - if params[:action] == 'edit'
+          - if @post.id?
             = f.label :募集ステータス, class: 'label'
             = f.radio_button :status, 'wanted', checked: post.wanted?, class: 'radio'
             | 募集中
@@ -35,5 +35,5 @@
         .control
           = f.submit submit_text, class: 'button is-success', data: { confirm: '投稿しますか？' }
         .control
-          - if params[:action] == 'edit'
-            = link_to 'キャンセル', :back, class: 'button is-danger'
+          - if @post.id?
+            = link_to 'キャンセル', post_path(@post.id), class: 'button is-danger'

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -9,12 +9,14 @@
                 = msg
       .field
         = f.label :リポジトリ, class: 'label'
-        - if params[:action] == 'new'
+        - if params[:action] == 'new' # 新規モード
           = f.text_field :repository, class: 'control input'
           p.help
             | 募集するリポジトリのURLを入力してください
-        - else
+        - elsif @post.id? # 編集モード(リポジトリは編集不可で表示)
           = f.text_field :repository, readonly: true, value: [post[:owner], post[:repository]].join("/"), class: 'control input disabled-style'
+        - else # 新規登録時の入力エラー(リポジトリは入力可能)
+          = f.text_field :repository, class: 'control input'
       .field
         = f.label :募集タイトル, class: 'label'
         = f.text_field :title, class: 'control input'

--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -9,12 +9,12 @@
                 = msg
       .field
         = f.label :リポジトリ, class: 'label'
-        - if @post.repository.blank?
+        - if params[:action] == 'new'
           = f.text_field :repository, class: 'control input'
           p.help
             | 募集するリポジトリのURLを入力してください
         - else
-          = f.text_field :repository, class: 'control input'
+          = f.text_field :repository, readonly: true, value: [post[:owner], post[:repository]].join("/"), class: 'control input disabled-style'
       .field
         = f.label :募集タイトル, class: 'label'
         = f.text_field :title, class: 'control input'


### PR DESCRIPTION
## Issue番号
#299 #300 #301

## 予定時間/実績時間
1.5h / 7.0h

## What - なにを修正したか？
- Editモードではリポジトリ欄は、username / reponaname を表示する（ReadOnlyにする）
- Editモードで入力エラーがあった場合に、募集ステータスとキャンセルが非表示になる対応
- Editモードでキャンセルボタンを押下した際の処理内容を見直し

## Why - なぜ修正したか？
更新時もリポジトリ存在チェックが実行されるため、／区切りで文字列を組み立てておく
必要があるため。
<!-- 変更の目的 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- New （リポジトリ欄は入力可）
![スクリーンショット 2019-03-09 11 44 07](https://user-images.githubusercontent.com/40923242/54065202-ae4baf00-4260-11e9-88b7-abd0194a83a2.png)
- New （バリデーションエラー：リポジトリ欄は入力可能状態を保つ）
![スクリーンショット 2019-03-09 11 47 26](https://user-images.githubusercontent.com/40923242/54065227-2a45f700-4261-11e9-88f8-f4aeb6e72947.png)
- Edit （リポジトリ欄は入力不可）
![スクリーンショット 2019-03-09 11 52 36](https://user-images.githubusercontent.com/40923242/54065279-e7385380-4261-11e9-8d6f-1ba9e85abf5c.png)
- Edit（バリデーションエラー：募集ステータスやキャンセルボタンは非表示にならないこと）
![スクリーンショット 2019-03-09 11 54 26](https://user-images.githubusercontent.com/40923242/54065292-25ce0e00-4262-11e9-8762-30b386a7dc4e.png)
- Edit　キャンセル押下時の挙動見直し
　:backの指定だと「Flash時：posts/XX」は、一個前の状態「＝編集ボタン押下前 ：posts/XX/edit」に遷移し「プロジェクト詳細：posts/show/XX」へ遷移しない。なので、：back指定を取りやめ。（URL動的生成に変更）
◆キャンセル押下前（Flash時）
![スクリーンショット 2019-03-09 11 54 26](https://user-images.githubusercontent.com/40923242/54065292-25ce0e00-4262-11e9-8762-30b386a7dc4e.png)
↓キャンセル押下 posts/showへ遷移すること
![スクリーンショット 2019-03-09 12 03 24](https://user-images.githubusercontent.com/40923242/54065373-5ebab280-4263-11e9-9a6c-8ebfccfb808e.png)

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
