### PR TITLE
MessageBoardのデザイン修正

### DIFF
--- a/app/assets/stylesheets/postsshow.css
+++ b/app/assets/stylesheets/postsshow.css
@@ -218,6 +218,44 @@
   margin-left: 3%;
 }
 
+#show-comment li {
+  display: block;
+  border-top: 1px solid;
+  margin-bottom: 30px;
+}
+
+#show-comment .message {
+  background-color: initial;
+  margin-bottom: initial;
+  margin-top: 10px;
+}
+
+#show-comment .message-header {
+  background-color: #f9fbfe;
+  color: initial;
+  padding: 0.50em 0.75em;
+  border: solid 1px #cdc8c8;
+  border-bottom: 0px;
+}
+
+#show-comment .message-header a {
+  color: red;
+}
+
+#show-comment .show-owner-img {
+  margin: 10px 0px 5px 5px;
+}
+
+#show-comment .message-body {
+  padding: 0.50em 0.75em;
+  border: solid 1px #cdc8c8;
+}
+
+#show-comment .message-time {
+  font-size: 0.75rem;
+  float: right;
+}
+
 /*=========================
         4.show-buttons
 ===========================*/

--- a/app/assets/stylesheets/postsshow.css
+++ b/app/assets/stylesheets/postsshow.css
@@ -72,7 +72,7 @@
   text-align: left;
 }
 
-.show-post-right {  
+.show-post-right {
   width: 120px;
   display: flex;
   justify-content: flex-end;
@@ -192,6 +192,31 @@
 /*=========================
         3.show-comment
 ===========================*/
+
+#show-comment {
+  background-color: #fff;
+  padding: 15px;
+  margin-bottom: 50px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+
+#show-comment .show-comment {
+  padding: 0.75rem;
+}
+
+#show-comment .title {
+  font-size: 1.5rem;
+  border-bottom: 1px solid;
+}
+
+#show-comment .input {
+  max-width: 88%;
+}
+
+#show-comment .button {
+  max-width: 9%;
+  margin-left: 3%;
+}
 
 /*=========================
         4.show-buttons

--- a/app/javascript/components/organisms/MessageBoard.vue
+++ b/app/javascript/components/organisms/MessageBoard.vue
@@ -1,11 +1,11 @@
 <template lang="pug">
 form(@submit.prevent="submit")
   .tile.is-ancestor.show-comment
-    .tile.is-vertical.box.is-9
-      .title.has-background-grey-lighter フィード
-      input.input(type="text" placeholder="コメント" v-model="content")
-      br
-      button(type="submit").button.is-info 投稿
+    .tile.is-vertical
+      .title コメント
+      .submit-area
+        input.input(type="text" placeholder="コメント" v-model="content")
+        button(type="submit").button.is-danger.is-rounded 投稿
       br
       .list
         li(v-for="message in messages" :key="message.id").list-item

--- a/app/javascript/components/organisms/MessageBoard.vue
+++ b/app/javascript/components/organisms/MessageBoard.vue
@@ -7,9 +7,19 @@ form(@submit.prevent="submit")
         input.input(type="text" placeholder="コメント" v-model="content")
         button(type="submit").button.is-danger.is-rounded 投稿
       br
-      .list
-        li(v-for="message in messages" :key="message.id").list-item
-          | {{ `${message.time } | ${message.content}` }}
+
+      li(v-for="message in messages" :key="message.id").message-wrapper
+        // TODO: サンプル画像(機能実装後、修正すること)
+        //img(src="https://avatars1.githubusercontent.com/u/40492325?v=4" size="30x30" alt="userIcon").show-owner-img
+        .message
+          // TODO: ユーザー名と削除ボタン(機能実装後、修正すること)
+          .message-header
+            //p ユーザー名
+            //a(href="#") 削除
+          .message-body
+            | {{ `${message.content}` }}
+        .message-time
+          | {{ `${message.time }` }}
 </template>
 
 <script>


### PR DESCRIPTION
## Issue番号
170

## 予定時間/実績時間
3~4h?

## What - なにを修正したか？
- コメント欄のデザイン/レイアウト修正
- ユーザー情報と紐づいた時に備えてのデザイン付与

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 補足
messageとuserを紐づけたりとか、vueに引っ張ってきたりとか時間かかりそうだしスコープ外だと思ったので、とりあえずデザイン優先しました。

下記のユーザーアイコンが表示されている画像は、classやcssだけ当てて現在はコメントアウトしているもの。
<img width="1280" alt="スクリーンショット 2019-03-09 16 24 39" src="https://user-images.githubusercontent.com/40492325/54067941-c4219a00-4289-11e9-8873-9d5d94701688.png">

---

下記画像は、[ userとメッセージの紐づけ、削除機能実装 ]前の暫定デザイン。PRはこの内容です。
<img width="1273" alt="スクリーンショット 2019-03-09 16 29 34" src="https://user-images.githubusercontent.com/40492325/54067943-c8e64e00-4289-11e9-9207-02d34631b753.png">

---
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

後、参考までに修正前の対象箇所デザインと、Figma URL載せときます。
https://www.figma.com/file/EIj8A4jV7ksxwESWRKYuiKrR/Untitled?node-id=0%3A1

<img width="1255" alt="スクリーンショット 2019-03-09 16 46 45" src="https://user-images.githubusercontent.com/40492325/54068042-24650b80-428b-11e9-849f-3fc6e2e4ca2e.png">
