### PR TITLE
posts#indexの並び順変更

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -73,7 +73,7 @@ class PostsController < ApplicationController
 
     def search_posts
       posts = []
-      Post.order(status: "ASC", updated_at: "DESC").select() do |repo|
+      Post.order(created_at: "DESC").select() do |repo|
         client = GithubOss::GithubFetcher.new(repo.owner_and_repository)
         post = {
           "id" => repo.id,

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -73,7 +73,7 @@ class PostsController < ApplicationController
 
     def search_posts
       posts = []
-      Post.order("id").select() do |repo|
+      Post.order(status: "ASC", updated_at: "DESC").select() do |repo|
         client = GithubOss::GithubFetcher.new(repo.owner_and_repository)
         post = {
           "id" => repo.id,


### PR DESCRIPTION
## Issue番号
to close #308 

## 予定時間/実績時間

## What - なにを修正したか？
- Postインスタンスを取得のorderメソッド修正

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 補足
issue #308 では、【募集中 && opened_onがnew】順に並べるとありましたが、updated_atで並べた方が細かい時間で並び替えできるので良いかと思って、`Post.order(status: "ASC", updated_at: "DESC")`こうしてます。
ご意見、修正依頼あればお気軽に🙆‍♂️