### PR TITLE
起案者のSlackワークスペースへの参加方法とチャンネル作成手順

### DIFF
--- a/app/views/posts/_form.html.slim
+++ b/app/views/posts/_form.html.slim
@@ -24,7 +24,8 @@
         = f.label :Slackチャンネル名, class: 'label'
         = f.text_field :slack_channel, class: 'control input', placeholder: "例: meister-hackersチャンネル"
         p.help
-          | Meister-HackersのSlack内で作成したチャンネル名を記載してください。
+          | Meister-HackersのSlackに参加し、作成したチャンネル名を記載してください。
+          a.help href="https://meister-hackers.slack.com/join/shared_invite/enQtNTYyMzAyNDM2MjI2LTAzYjIyYmY0ZWM5YWQ2ODc3M2Y4MGI3MWYxMTVmODk5NWU0NmNmMDc1NjVjMDBmODcxZDkyNjUwZTgxMTM0M2I" target="_blank" Meister Hackersへの参加はこちら
       .field
         = f.label :募集概要, class: 'label'
         = f.text_area :content, class: 'control textarea', placeholder: "1000文字以内で入力"


### PR DESCRIPTION
## Issue番号
#324 

## 予定時間/実績時間
1.0h / 1.5h

## What - なにを修正したか？
起案者にプロジェクト登録のタイミングでSlackに参加させる。
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 画面イメージ
![スクリーンショット 2019-03-10 7 21 01](https://user-images.githubusercontent.com/40923242/54078070-48fdc980-4305-11e9-83d8-8bc5281feb9e.png)
- 操作イメージ

1. リンクを踏む
![スクリーンショット 2019-03-10 7 21 01](https://user-images.githubusercontent.com/40923242/54078126-451e7700-4306-11e9-9869-067360887368.png)

2. Slack参加
![スクリーンショット 2019-03-10 7 24 38](https://user-images.githubusercontent.com/40923242/54078127-4a7bc180-4306-11e9-90fd-087cd7d2c059.png)

3. メール確認①
![スクリーンショット 2019-03-10 7 25 37](https://user-images.githubusercontent.com/40923242/54078193-6df33c00-4307-11e9-85f6-d3a5bc7072be.png)

4. メール確認② 
![スクリーンショット 2019-03-10 7 26 44](https://user-images.githubusercontent.com/40923242/54078135-59fb0a80-4306-11e9-9925-a4dab9508c8f.png)

5. Slack参加設定 
![スクリーンショット 2019-03-10 7 27 44](https://user-images.githubusercontent.com/40923242/54078207-a72bac00-4307-11e9-8988-740d638e621a.png)

6. Slack参加 
![スクリーンショット 2019-03-10 7 28 40](https://user-images.githubusercontent.com/40923242/54078248-5c5e6400-4308-11e9-8dd3-cc40323e3fda.png)


7. チャンネル作成 
![スクリーンショット 2019-03-10 7 29 03](https://user-images.githubusercontent.com/40923242/54078140-6a12ea00-4306-11e9-94b8-2f728463adc5.png)

8. 作成したチャンネルを投稿画面で打ち込む。 

## Why - なぜ修正したか？
今のレイアウトだと起案者がプロジェクト参加経験がないユーザの場合に、チャンネル登録ができないため。

<!-- 変更の目的 -->

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
