### PR TITLE
MyPageFormの入力値検証

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -54,7 +54,7 @@ class ProfilesController < ApplicationController
         render json: { status: 200 }
         flash[:notice] = "編集に成功しました"
       else
-        render json: { status: 500 }
+        render json: { status: 500, errors: profile.errors }
       end
     end
   end

--- a/app/javascript/components/organisms/MyPageForm.vue
+++ b/app/javascript/components/organisms/MyPageForm.vue
@@ -85,14 +85,13 @@ export default {
       const profileUrl = `${baseUrl.replace("edit", "profiles")}/${this.profile.id}`;
       Axios.put(profileUrl, this.profile)
         .then((response) => {
-        if (response.data.status === 200) {
-          location.href = baseUrl.replace("edit", "");
-        }
-        if (response.data.status === 500) {
-          console.log(response.data.errors);
-          this.errMessages = response.data.errors
-        }       
-      });
+          if (response.data.status === 200) {
+            location.href = baseUrl.replace("edit", "");
+          }
+          if (response.data.status === 500) {
+            this.errMessages = response.data.errors;
+          }    
+        });
     },
     cancel() {
       const baseUrl = location.href;

--- a/app/javascript/components/organisms/MyPageForm.vue
+++ b/app/javascript/components/organisms/MyPageForm.vue
@@ -11,6 +11,9 @@
               | {{ this.user.name }}
             td.account-header-right
               a.cancel-button(type="button" @click="cancel") キャンセル
+        ul(v-if="errMessages")
+          li(v-for="errMsg in errMessages")
+            span {{ errMsg[0] }}
         .account アカウント
         .field
           .label 都道府県
@@ -24,27 +27,15 @@
         .field
           .label GitHub URL
           input.input(type="text" v-model="profile.github_url")
-        .err-msg(v-if="errMessages.github_url")
-          span(v-for="errMsg in errMessages.github_url")
-            | {{ errMsg }}
         .field
           .label Twitter URL
           input.input(type="text" v-model="profile.twitter_url")
-        .err-msg(v-if="errMessages.twitter_url")
-          span(v-for="errMsg in errMessages.twitter_url")
-            | {{ errMsg }}
         .field
           .label Facebook URL
           input.input(type="text" v-model="profile.facebook_url")
-        .err-msg(v-if="errMessages.facebook_url")
-          span(v-for="errMsg in errMessages.facebook_url")
-            | {{ errMsg }}
         .field
           .label Blog URL
           input.input(type="text" v-model="profile.blog_url")
-        .err-msg(v-if="errMessages.blog_url")
-          span(v-for="errMsg in errMessages.blog_url")
-            | {{ errMsg }}
         button.button(type="submit").is-primary 更新
 </template>
 
@@ -67,12 +58,7 @@ export default {
         name: "",
         avatar: "",
       },
-      errMessages: {
-        github_url: null,
-        twitter_url: null,
-        facebook_url: null,
-        blog_url: null,         
-      }
+      errMessages: null,
     };
   },
   mounted() {
@@ -196,9 +182,7 @@ export default {
     border-radius: 10px;
   }
 
-  .err-msg {
-    text-align: left;
+  ul {
     color: red;
-    margin-top: -30px;
   }
 </style>

--- a/app/javascript/components/organisms/MyPageForm.vue
+++ b/app/javascript/components/organisms/MyPageForm.vue
@@ -24,15 +24,27 @@
         .field
           .label GitHub URL
           input.input(type="text" v-model="profile.github_url")
+        .err-msg(v-if="errMessages.github_url")
+          span(v-for="errMsg in errMessages.github_url")
+            | {{ errMsg }}
         .field
           .label Twitter URL
           input.input(type="text" v-model="profile.twitter_url")
+        .err-msg(v-if="errMessages.twitter_url")
+          span(v-for="errMsg in errMessages.twitter_url")
+            | {{ errMsg }}
         .field
           .label Facebook URL
           input.input(type="text" v-model="profile.facebook_url")
+        .err-msg(v-if="errMessages.facebook_url")
+          span(v-for="errMsg in errMessages.facebook_url")
+            | {{ errMsg }}
         .field
           .label Blog URL
           input.input(type="text" v-model="profile.blog_url")
+        .err-msg(v-if="errMessages.blog_url")
+          span(v-for="errMsg in errMessages.blog_url")
+            | {{ errMsg }}
         button.button(type="submit").is-primary 更新
 </template>
 
@@ -55,6 +67,12 @@ export default {
         name: "",
         avatar: "",
       },
+      errMessages: {
+        github_url: null,
+        twitter_url: null,
+        facebook_url: null,
+        blog_url: null,         
+      }
     };
   },
   mounted() {
@@ -80,9 +98,15 @@ export default {
       const baseUrl = location.href;
       const profileUrl = `${baseUrl.replace("edit", "profiles")}/${this.profile.id}`;
       Axios.put(profileUrl, this.profile)
-        .then(() => {
+        .then((response) => {
+        if (response.data.status === 200) {
           location.href = baseUrl.replace("edit", "");
-        });
+        }
+        if (response.data.status === 500) {
+          console.log(response.data.errors);
+          this.errMessages = response.data.errors
+        }       
+      });
     },
     cancel() {
       const baseUrl = location.href;
@@ -172,4 +196,9 @@ export default {
     border-radius: 10px;
   }
 
+  .err-msg {
+    text-align: left;
+    color: red;
+    margin-top: -30px;
+  }
 </style>

--- a/app/javascript/components/organisms/MyPageForm.vue
+++ b/app/javascript/components/organisms/MyPageForm.vue
@@ -90,7 +90,7 @@ export default {
           }
           if (response.data.status === 500) {
             this.errMessages = response.data.errors;
-          }    
+          }
         });
     },
     cancel() {

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -19,5 +19,11 @@
 
 
 class Profile < ApplicationRecord
+  INVALID_URL_FROMAT = "URLの形式が不正です"
   belongs_to :user
+
+  validates :github_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FROMAT }
+  validates :twitter_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FROMAT }
+  validates :facebook_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FROMAT }
+  validates :blog_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FROMAT }
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -23,11 +23,11 @@ class Profile < ApplicationRecord
   MAX_LENGTH_ERROR = "%<field>sは、%<length>s文字以内で入力して下さい"
   belongs_to :user
 
-  validates :area, :length => { maximum: 9, message: MAX_LENGTH_ERROR % { field: "都道府県", length: 9 }}
-  validates :sex, :length => { maximum: 5, message: MAX_LENGTH_ERROR % { field: "性別", length: 5 }}
-  validates :introduction, :length => { maximum: 160, message: MAX_LENGTH_ERROR % { field: "自己紹介", length: 160 }}
-  validates :github_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field: "GitHub" }}, :length => { maximum: 2000, message: MAX_LENGTH_ERROR % { field: "GitHub URL", length: 2000 }}
-  validates :twitter_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field: "Twitter" }}, :length => { maximum: 2000, message: MAX_LENGTH_ERROR % { field: "Twitter URL", length: 2000 }}
-  validates :facebook_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field: "Facebook" }}, :length => { maximum: 2000, message: MAX_LENGTH_ERROR % { field: "Facebook URL", length: 2000 }}
-  validates :blog_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field: "Blog" }}, :length => { maximum: 2000, message: MAX_LENGTH_ERROR % { field: "Blog URL", length: 2000 }}
+  validates :area, length: { maximum: 9, message: MAX_LENGTH_ERROR % { field: "都道府県", length: 9 } }
+  validates :sex, length: { maximum: 5, message: MAX_LENGTH_ERROR % { field: "性別", length: 5 } }
+  validates :introduction, length: { maximum: 160, message: MAX_LENGTH_ERROR % { field: "自己紹介", length: 160 } }
+  validates :github_url, allow_blank: true, format: { with: /\A#{URI.regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field: "GitHub" } }, length: { maximum: 2000, message: MAX_LENGTH_ERROR % { field: "GitHub URL", length: 2000 } }
+  validates :twitter_url, allow_blank: true, format: { with: /\A#{URI.regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field: "Twitter" } }, length: { maximum: 2000, message: MAX_LENGTH_ERROR % { field: "Twitter URL", length: 2000 } }
+  validates :facebook_url, allow_blank: true, format: { with: /\A#{URI.regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field: "Facebook" } }, length: { maximum: 2000, message: MAX_LENGTH_ERROR % { field: "Facebook URL", length: 2000 } }
+  validates :blog_url, allow_blank: true, format: { with: /\A#{URI.regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field: "Blog" } }, length: { maximum: 2000, message: MAX_LENGTH_ERROR % { field: "Blog URL", length: 2000 } }
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -19,11 +19,15 @@
 
 
 class Profile < ApplicationRecord
-  INVALID_URL_FROMAT = "URLの形式が不正です"
+  INVALID_URL_FORMAT = "%<field>s URLの形式が不正です"
+  MAX_LENGTH_ERROR = "%<field>sは、%<length>s文字以内で入力して下さい"
   belongs_to :user
 
-  validates :github_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FROMAT }
-  validates :twitter_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FROMAT }
-  validates :facebook_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FROMAT }
-  validates :blog_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FROMAT }
+  validates :area, :length => {:maximum => 9, :message => MAX_LENGTH_ERROR % { field:"都道府県", length:9 }}
+  validates :sex, :length => {:maximum => 5, :message => MAX_LENGTH_ERROR % { field:"性別", length:5 }}
+  validates :introduction, :length => {:maximum => 160, :message => MAX_LENGTH_ERROR % { field:"自己紹介", length:160 }}
+  validates :github_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field:"GitHub" }}, :length => {:maximum => 2000, :message => MAX_LENGTH_ERROR % { field:"GitHub URL", length:2000 }}
+  validates :twitter_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field:"Twitter" }}, :length => {:maximum => 2000, :message => MAX_LENGTH_ERROR % { field:"Twitter URL", length:2000 }}
+  validates :facebook_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field:"Facebook" }}, :length => {:maximum => 2000, :message => MAX_LENGTH_ERROR % { field:"Facebook URL", length:2000 }}
+  validates :blog_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field:"Blog" }}, :length => {:maximum => 2000, :message => MAX_LENGTH_ERROR % { field:"Blog URL", length:2000 }}
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -23,11 +23,11 @@ class Profile < ApplicationRecord
   MAX_LENGTH_ERROR = "%<field>sは、%<length>s文字以内で入力して下さい"
   belongs_to :user
 
-  validates :area, :length => {:maximum => 9, :message => MAX_LENGTH_ERROR % { field:"都道府県", length:9 }}
-  validates :sex, :length => {:maximum => 5, :message => MAX_LENGTH_ERROR % { field:"性別", length:5 }}
-  validates :introduction, :length => {:maximum => 160, :message => MAX_LENGTH_ERROR % { field:"自己紹介", length:160 }}
-  validates :github_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field:"GitHub" }}, :length => {:maximum => 2000, :message => MAX_LENGTH_ERROR % { field:"GitHub URL", length:2000 }}
-  validates :twitter_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field:"Twitter" }}, :length => {:maximum => 2000, :message => MAX_LENGTH_ERROR % { field:"Twitter URL", length:2000 }}
-  validates :facebook_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field:"Facebook" }}, :length => {:maximum => 2000, :message => MAX_LENGTH_ERROR % { field:"Facebook URL", length:2000 }}
-  validates :blog_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field:"Blog" }}, :length => {:maximum => 2000, :message => MAX_LENGTH_ERROR % { field:"Blog URL", length:2000 }}
+  validates :area, :length => { maximum: 9, message: MAX_LENGTH_ERROR % { field: "都道府県", length: 9 }}
+  validates :sex, :length => { maximum: 5, message: MAX_LENGTH_ERROR % { field: "性別", length: 5 }}
+  validates :introduction, :length => { maximum: 160, message: MAX_LENGTH_ERROR % { field: "自己紹介", length: 160 }}
+  validates :github_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field: "GitHub" }}, :length => { maximum: 2000, message: MAX_LENGTH_ERROR % { field: "GitHub URL", length: 2000 }}
+  validates :twitter_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field: "Twitter" }}, :length => { maximum: 2000, message: MAX_LENGTH_ERROR % { field: "Twitter URL", length: 2000 }}
+  validates :facebook_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field: "Facebook" }}, :length => { maximum: 2000, message: MAX_LENGTH_ERROR % { field: "Facebook URL", length: 2000 }}
+  validates :blog_url, allow_blank: true, format: { with: /\A#{URI::regexp(%w(http https))}\z/, message: INVALID_URL_FORMAT % { field: "Blog" }}, :length => { maximum: 2000, message: MAX_LENGTH_ERROR % { field: "Blog URL", length: 2000 }}
 end


### PR DESCRIPTION
## Issue番号
#294

## 予定時間/実績時間
3.0h / 10.0h ( 式展開やVueの配列Mustacheに時間がかかった )

## What - なにを修正したか？
各項目のバリデーション（入力チェック）を追加。
都道府県：9文字
性別　　：5文字
自己紹介：160文字
URL　　：2000文字、http 又は https プロトコルのみ許容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
![スクリーンショット 2019-03-16 10 34 02](https://user-images.githubusercontent.com/40923242/54469105-16594280-47d7-11e9-801c-2cb8c3236099.png)

## Why - なぜ修正したか？
> URL（リンク）をユーザが自由に登録できるというのは、怖いことなので
> 仕様的にも、DIVコードレビュー対策としても対応したいです。
> JavaScriptスキーム（javascript:〜)を禁止（http/httpsのみ有効）は入れます。

<!-- 変更の目的 -->

## 補足
参考情報　https://github.com/WEBsinjyuku/meister-hackers/issues/199#issuecomment-470471233
<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
