### PR TITLE
posts/index 7件以上の投稿時の画面レイアウト崩れ対応

### DIFF
--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -22,6 +22,9 @@ javascript:
   var posts = #{{ @posts.to_json }}
 = javascript_pack_tag 'posts/index.js'
 css:
+  body {
+    height: auto;
+  }
   .topic {
     color : RGB(0, 209, 178) !important;
     background-color : RGB(169, 245, 225, 0.1) !important;


### PR DESCRIPTION
## Issue番号
#349 

## 予定時間/実績時間
0.5h / 0.5h
## What - なにを修正したか？
7件以上の投稿がある場合でも、画面下部の背景色が白くならないよう修正
（具体的に、Slim側でCSS個別定義した）

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 変更前
![スクリーンショット 2019-03-16 11 27 24](https://user-images.githubusercontent.com/40923242/54469677-9040fa00-47de-11e9-9d31-9cfd26691659.png)

- 変更後
![スクリーンショット 2019-03-16 11 22 48](https://user-images.githubusercontent.com/40923242/54469655-3fc99c80-47de-11e9-8ce2-7e1a8e6e61c7.png)

## Why - なぜ修正したか？
画面デザイン崩れ対応のため。
<!-- 変更の目的 -->

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
