### PR TITLE
posts/show height値が大きい場合に画面下部が白くなる

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -28,8 +28,7 @@ a:hover {
 body {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  height: 1250px;
+  min-height: 1250px;
 }
 
 body {

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -22,9 +22,6 @@ javascript:
   var posts = #{{ @posts.to_json }}
 = javascript_pack_tag 'posts/index.js'
 css:
-  body {
-    height: auto;
-  }
   .topic {
     color : RGB(0, 209, 178) !important;
     background-color : RGB(169, 245, 225, 0.1) !important;


### PR DESCRIPTION
## Issue番号
#363 

## 予定時間/実績時間
1.0h / 0.5h

## What - なにを修正したか？
コメント投稿数が多い、募集メッセージが多い場合に画面下部が白くならないようCSS修正
height: auto; だと内容量が少ない場合にfooterの表示位置が上部になるため、indexも修正。

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- posts/show
【修正前】
![スクリーンショット 2019-03-16 21 36 40](https://user-images.githubusercontent.com/40923242/54475489-21db5680-4835-11e9-81eb-6daf8362d032.png)
【修正後】
![スクリーンショット 2019-03-16 21 37 05](https://user-images.githubusercontent.com/40923242/54475494-30297280-4835-11e9-83b4-d6ff7171ac96.png)
＊内容が少ない場合（footerが上にあがってこないこと）
![スクリーンショット 2019-03-16 21 38 27](https://user-images.githubusercontent.com/40923242/54475507-4e8f6e00-4835-11e9-8fd4-f48ee9249229.png)

- posts/index（画面下部が白くならないこと）
![スクリーンショット 2019-03-16 21 38 10](https://user-images.githubusercontent.com/40923242/54475522-636c0180-4835-11e9-81e1-1d43b14b6f5d.png)

## Why - なぜ修正したか？
デザイン崩れ対応

<!-- 変更の目的 -->

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
