### PR TITLE
MeaagesBoard 機能改善

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,9 +4,10 @@ class MessagesController < ApplicationController
   protect_from_forgery except: ["create"]
 
   def index
-    post = Post.find_by(id: params[:post_id])
+    post = Message.joins("LEFT JOIN users ON messages.user_id = users.id").where(post_id: params[:post_id])
+      .select("messages.id, messages.user_id, users.avatar_url, users.name, messages.content, messages.created_at")
     if post
-      render json: { status: 200, data: post.messages, signed_in: user_signed_in? }
+      render json: { status: 200, data: post, signed_in: user_signed_in? }
     else
       render json: { status: 500, data: [], signed_in: user_signed_in? }
     end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,9 +7,9 @@ class MessagesController < ApplicationController
     messages = Message.joins("LEFT JOIN users ON messages.user_id = users.id").where(post_id: params[:post_id])
       .select("messages.id, messages.user_id, users.avatar_url, users.name, messages.content, messages.created_at")
     if messages
-      render json: { status: 200, data: messages, signed_in: user_signed_in? }
+      render json: { status: 200, data: messages, signed_in: user_signed_in?, logged_in_user_id: current_user[:id] }
     else
-      render json: { status: 500, data: [], signed_in: user_signed_in? }
+      render json: { status: 500, data: [], signed_in: user_signed_in?, logged_in_user_id: current_user[:id] }
     end
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -20,7 +20,7 @@ class MessagesController < ApplicationController
       return
     end
 
-    message = post.messages.build(content: params[:content])
+    message = post.messages.build(content: params[:content], user_id: current_user[:id])
 
     if message.save
       render json: { status: 200 }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,10 +6,17 @@ class MessagesController < ApplicationController
   def index
     messages = Message.joins("LEFT JOIN users ON messages.user_id = users.id").where(post_id: params[:post_id])
       .select("messages.id, messages.user_id, users.avatar_url, users.name, messages.content, messages.created_at")
-    if messages
-      render json: { status: 200, data: messages, signed_in: user_signed_in?, logged_in_user_id: current_user[:id] }
+    
+    if user_signed_in?
+      logged_in_user_id = current_user[:id]
     else
-      render json: { status: 500, data: [], signed_in: user_signed_in?, logged_in_user_id: current_user[:id] }
+      logged_in_user_id = -1
+    end
+
+    if messages
+      render json: { status: 200, data: messages, signed_in: user_signed_in?, logged_in_user_id: logged_in_user_id }
+    else
+      render json: { status: 500, data: [], signed_in: user_signed_in?, logged_in_user_id: logged_in_user_id }
     end
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -6,7 +6,7 @@ class MessagesController < ApplicationController
   def index
     messages = Message.joins("LEFT JOIN users ON messages.user_id = users.id").where(post_id: params[:post_id])
       .select("messages.id, messages.user_id, users.avatar_url, users.name, messages.content, messages.created_at")
-    
+
     if user_signed_in?
       logged_in_user_id = current_user[:id]
     else
@@ -30,7 +30,7 @@ class MessagesController < ApplicationController
     end
 
     message = post.messages.build(content: params[:content], user_id: current_user[:id])
- 
+
     if message.save
       user = User.find_by(id: message.user_id)
       render json: { status: 200, data: [ message: message, user: user] }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -4,10 +4,10 @@ class MessagesController < ApplicationController
   protect_from_forgery except: ["create"]
 
   def index
-    post = Message.joins("LEFT JOIN users ON messages.user_id = users.id").where(post_id: params[:post_id])
+    messages = Message.joins("LEFT JOIN users ON messages.user_id = users.id").where(post_id: params[:post_id])
       .select("messages.id, messages.user_id, users.avatar_url, users.name, messages.content, messages.created_at")
-    if post
-      render json: { status: 200, data: post, signed_in: user_signed_in? }
+    if messages
+      render json: { status: 200, data: messages, signed_in: user_signed_in? }
     else
       render json: { status: 500, data: [], signed_in: user_signed_in? }
     end
@@ -22,8 +22,18 @@ class MessagesController < ApplicationController
     end
 
     message = post.messages.build(content: params[:content], user_id: current_user[:id])
-
+ 
     if message.save
+      user = User.find_by(id: message.user_id)
+      render json: { status: 200, data: [ message: message, user: user] }
+    else
+      render json: { status: 500 }
+    end
+  end
+
+  def destroy
+    message = Message.find_by(id: params[:id])
+    if message.delete
       render json: { status: 200 }
     else
       render json: { status: 500 }

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,6 +10,7 @@ class MessagesController < ApplicationController
     if user_signed_in?
       logged_in_user_id = current_user[:id]
     else
+      # 未ログイン時は-１とする
       logged_in_user_id = -1
     end
 

--- a/app/javascript/components/organisms/MessageBoard.vue
+++ b/app/javascript/components/organisms/MessageBoard.vue
@@ -9,20 +9,19 @@ form(@submit.prevent="submit")
       li(v-if="messages.length == 0" v-bind:class="{'signed-out': !signed_in}")
         | コメントはありません
       li(v-for="(message, index) in messages" :key="message.id" v-bind:class="{'signed-out': !signed_in && index == 0}").message-wrapper
-        // TODO: サンプル画像(機能実装後、修正すること)
-        | {{ message.message_id }}
-        | {{ message.user_id }}
-        | {{ message.avatar_url }}
-        //img(src="https://avatars1.githubusercontent.com/u/40492325?v=4" size="30x30" alt="userIcon").show-owner-img
-        .message
-          // TODO: ユーザー名と削除ボタン(機能実装後、修正すること)
-          .message-header
-            p {{ message.user_name }}
-            //a(href="#") 削除
-          .message-body
-            | {{ `${message.content}` }}
-        .message-time
-          | {{ `${message.time}` }}
+        table
+          tr
+            td.is-width-1
+              img(v-bind:src="message.avatar_url" size="30x30" alt="userIcon" v-if="message.avatar_url").show-owner-img
+            td.is-width-9
+              .message
+                .message-header
+                  p {{ message.user_name }}
+                  a.delete-button(type="button" @click="del(message.message_id, index)") 削除
+                .message-body
+                  | {{ `${message.content}` }}
+                .message-time
+                  | {{ `${message.time}` }}
 </template>
 
 <script>
@@ -65,11 +64,30 @@ export default {
           content: this.content,
         };
         Axios.post(messageUrl, data)
-          .then(() => {
-            this.messages.unshift({ content: this.content, time: moment().format("YYYY/MM/DD HH:mm") });
+          .then((response) => {
+            this.messages.unshift({
+              message_id: response.data.data[0]["message"]["id"],
+              user_id: response.data.data[0]["message"]["user_id"],
+              avatar_url: response.data.data[0]["user"]["avatar_url"],
+              user_name: response.data.data[0]["user"]["name"],
+              content: this.content,
+              time: moment().format("YYYY/MM/DD HH:mm")
+            });
             this.content = "";
           });
       }
+    },
+    del: function (id, index) {
+      const messageDeleteUrl = `${location.href}/messages/${id}`;
+      console.log(messageDeleteUrl);
+      Axios.delete(messageDeleteUrl)
+        .then((response) => {
+          if (response.data.status === 200) {
+            this.messages.splice(index, 1)
+          }
+          if (response.data.status === 500) {
+          }
+        });
     },
   },
 };
@@ -106,7 +124,19 @@ export default {
     border-top: 1px solid;
     margin-bottom: 30px;
   }
+  
+  table {
+    width: 100%;
+  }
 
+  .is-width-1 {
+    text-align: center;    
+    width: 8%;
+  }
+
+  .is-width-9 {
+    width: 90%
+  }
   .message {
     background-color: initial;
     margin-bottom: initial;
@@ -137,5 +167,9 @@ export default {
   .message-time {
     font-size: 0.75rem;
     float: right;
+  }
+
+  .delete-button {
+    color: red !important;
   }
 </style>

--- a/app/javascript/components/organisms/MessageBoard.vue
+++ b/app/javascript/components/organisms/MessageBoard.vue
@@ -14,7 +14,7 @@ form(@submit.prevent="submit")
         .message
           // TODO: ユーザー名と削除ボタン(機能実装後、修正すること)
           .message-header
-            //p ユーザー名
+            p {{ message.user_id }}
             //a(href="#") 削除
           .message-body
             | {{ `${message.content}` }}
@@ -40,7 +40,11 @@ export default {
       .then((response) => {
         if (response.data.data) {
           response.data.data.map((h) => {
-            this.messages.unshift({ content: h.content, time: moment(h.created_at).format("YYYY/MM/DD HH:mm") });
+            this.messages.unshift({ 
+              user_id: h.user_id,
+              content: h.content,
+              time: moment(h.created_at).format("YYYY/MM/DD HH:mm")
+            });
           });
         }
         this.signed_in = response.data.signed_in;

--- a/app/javascript/components/organisms/MessageBoard.vue
+++ b/app/javascript/components/organisms/MessageBoard.vue
@@ -43,13 +43,13 @@ export default {
       .then((response) => {
         if (response.data.data) {
           response.data.data.map((h) => {
-            this.messages.unshift({ 
-              message_id : h.id,
+            this.messages.unshift({
+              message_id: h.id,
               user_id: h.user_id,
               avatar_url: h.avatar_url,
               user_name: h.name,
               content: h.content,
-              time: moment(h.created_at).format("YYYY/MM/DD HH:mm")
+              time: moment(h.created_at).format("YYYY/MM/DD HH:mm"),
             });
           });
         }
@@ -73,7 +73,7 @@ export default {
               avatar_url: response.data.data[0]["user"]["avatar_url"],
               user_name: response.data.data[0]["user"]["name"],
               content: this.content,
-              time: moment().format("YYYY/MM/DD HH:mm")
+              time: moment().format("YYYY/MM/DD HH:mm"),
             });
             this.content = "";
           });
@@ -84,11 +84,7 @@ export default {
       console.log(messageDeleteUrl);
       Axios.delete(messageDeleteUrl)
         .then((response) => {
-          if (response.data.status === 200) {
-            this.messages.splice(index, 1)
-          }
-          if (response.data.status === 500) {
-          }
+          this.messages.splice(index, 1);
         });
     },
   },
@@ -126,13 +122,13 @@ export default {
     border-top: 1px solid;
     margin-bottom: 30px;
   }
-  
+
   table {
     width: 100%;
   }
 
   .is-width-1 {
-    text-align: center;    
+    text-align: center;
     width: 8%;
   }
 

--- a/app/javascript/components/organisms/MessageBoard.vue
+++ b/app/javascript/components/organisms/MessageBoard.vue
@@ -17,7 +17,7 @@ form(@submit.prevent="submit")
               .message
                 .message-header
                   p {{ message.user_name }}
-                  a.delete-button(type="button" @click="del(message.message_id, index)") 削除
+                  a.delete-button(type="button" v-if="message.user_id == logged_in_user_id" @click="del(message.message_id, index)") 削除
                 .message-body
                   | {{ `${message.content}` }}
                 .message-time
@@ -34,6 +34,7 @@ export default {
       messages: [],
       content: "",
       signed_in: false,
+      logged_in_user_id: null,
     };
   },
   mounted() {
@@ -53,6 +54,7 @@ export default {
           });
         }
         this.signed_in = response.data.signed_in;
+        this.logged_in_user_id = response.data.logged_in_user_id;
       });
   },
   methods: {

--- a/app/javascript/components/organisms/MessageBoard.vue
+++ b/app/javascript/components/organisms/MessageBoard.vue
@@ -68,10 +68,10 @@ export default {
         Axios.post(messageUrl, data)
           .then((response) => {
             this.messages.unshift({
-              message_id: response.data.data[0]["message"]["id"],
-              user_id: response.data.data[0]["message"]["user_id"],
-              avatar_url: response.data.data[0]["user"]["avatar_url"],
-              user_name: response.data.data[0]["user"]["name"],
+              message_id: response.data.data[0].message["id"],
+              user_id: response.data.data[0].message["user_id"],
+              avatar_url: response.data.data[0].user["avatar_url"],
+              user_name: response.data.data[0].user["name"],
               content: this.content,
               time: moment().format("YYYY/MM/DD HH:mm"),
             });
@@ -79,11 +79,10 @@ export default {
           });
       }
     },
-    del: function (id, index) {
+    del: function delete(id, index) {
       const messageDeleteUrl = `${location.href}/messages/${id}`;
-      console.log(messageDeleteUrl);
       Axios.delete(messageDeleteUrl)
-        .then((response) => {
+        .then(() => {
           this.messages.splice(index, 1);
         });
     },

--- a/app/javascript/components/organisms/MessageBoard.vue
+++ b/app/javascript/components/organisms/MessageBoard.vue
@@ -17,7 +17,7 @@ form(@submit.prevent="submit")
               .message
                 .message-header
                   p {{ message.user_name }}
-                  a.delete-button(type="button" v-if="message.user_id == logged_in_user_id" @click="del(message.message_id, index)") 削除
+                  a.delete-button(type="button" v-if="message.user_id == logged_in_user_id" @click="doDelete(message.message_id, index)") 削除
                 .message-body
                   | {{ `${message.content}` }}
                 .message-time
@@ -68,10 +68,10 @@ export default {
         Axios.post(messageUrl, data)
           .then((response) => {
             this.messages.unshift({
-              message_id: response.data.data[0].message["id"],
-              user_id: response.data.data[0].message["user_id"],
-              avatar_url: response.data.data[0].user["avatar_url"],
-              user_name: response.data.data[0].user["name"],
+              message_id: response.data.data[0].message.id,
+              user_id: response.data.data[0].message.user_id,
+              avatar_url: response.data.data[0].user.avatar_url,
+              user_name: response.data.data[0].user.name,
               content: this.content,
               time: moment().format("YYYY/MM/DD HH:mm"),
             });
@@ -79,12 +79,11 @@ export default {
           });
       }
     },
-    del: function (id, index) {
+    doDelete(id, index) {
       const messageDeleteUrl = `${location.href}/messages/${id}`;
       Axios.delete(messageDeleteUrl)
         .then((response) => {
           if (response.data.status === 200) {
-            console.log(this.messages);
             this.messages.splice(index, 1);
           }
           if (response.data.status === 500) {

--- a/app/javascript/components/organisms/MessageBoard.vue
+++ b/app/javascript/components/organisms/MessageBoard.vue
@@ -10,11 +10,14 @@ form(@submit.prevent="submit")
         | コメントはありません
       li(v-for="(message, index) in messages" :key="message.id" v-bind:class="{'signed-out': !signed_in && index == 0}").message-wrapper
         // TODO: サンプル画像(機能実装後、修正すること)
+        | {{ message.message_id }}
+        | {{ message.user_id }}
+        | {{ message.avatar_url }}
         //img(src="https://avatars1.githubusercontent.com/u/40492325?v=4" size="30x30" alt="userIcon").show-owner-img
         .message
           // TODO: ユーザー名と削除ボタン(機能実装後、修正すること)
           .message-header
-            p {{ message.user_id }}
+            p {{ message.user_name }}
             //a(href="#") 削除
           .message-body
             | {{ `${message.content}` }}
@@ -41,7 +44,10 @@ export default {
         if (response.data.data) {
           response.data.data.map((h) => {
             this.messages.unshift({ 
+              message_id : h.id,
               user_id: h.user_id,
+              avatar_url: h.avatar_url,
+              user_name: h.name,
               content: h.content,
               time: moment(h.created_at).format("YYYY/MM/DD HH:mm")
             });

--- a/app/javascript/components/organisms/MessageBoard.vue
+++ b/app/javascript/components/organisms/MessageBoard.vue
@@ -79,11 +79,17 @@ export default {
           });
       }
     },
-    del: function delete(id, index) {
+    del: function (id, index) {
       const messageDeleteUrl = `${location.href}/messages/${id}`;
       Axios.delete(messageDeleteUrl)
-        .then(() => {
-          this.messages.splice(index, 1);
+        .then((response) => {
+          if (response.data.status === 200) {
+            console.log(this.messages);
+            this.messages.splice(index, 1);
+          }
+          if (response.data.status === 500) {
+            console.log("コメント削除失敗");
+          }
         });
     },
   },

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -9,10 +9,13 @@
 #  post_id    :bigint(8)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  user_id    :bigint(8)
 #
 
 
 class Message < ApplicationRecord
+  MAX_LENGTH_ERROR = "%<field>sは、%<length>s文字以内で入力して下さい"
   belongs_to :post
-  validates :content, length: { maximum: 100 }, presence: true
+
+  validates :content, length: { maximum: 100, message: MAX_LENGTH_ERROR % { field: "コメント", length: 100 } }, presence: true
 end

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -71,9 +71,8 @@ section#show-comment
 
 
 
-
-- if user_signed_in?
-  section#show-button
+section#show-button
+  - if user_signed_in?
     .show-button-box
       - if @user == current_user
         = link_to edit_post_path(params[:id]), class: "show-button my-shadow show-button-join"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   end
 
   resources :posts, only: %i(new create edit update show index destroy) do
-    resources :messages, only: %i(index create)
+    resources :messages, only: %i(index create destroy)
   end
 
   get "error/404", controller: 'application', action: 'render_404'

--- a/db/migrate/20190316230307_add_column_to_messages.rb
+++ b/db/migrate/20190316230307_add_column_to_messages.rb
@@ -1,5 +1,5 @@
 class AddColumnToMessages < ActiveRecord::Migration[5.2]
   def change
-    add_column :messages, :user_id, :bigint, limit: 8
+    add_column :messages, :user_id, :bigint
   end
 end

--- a/db/migrate/20190316230307_add_column_to_messages.rb
+++ b/db/migrate/20190316230307_add_column_to_messages.rb
@@ -1,0 +1,5 @@
+class AddColumnToMessages < ActiveRecord::Migration[5.2]
+  def change
+    add_column :messages, :user_id, :bigint, limit: 8
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_08_053730) do
+ActiveRecord::Schema.define(version: 2019_03_16_230307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2019_03_08_053730) do
     t.bigint "post_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id"
     t.index ["post_id"], name: "index_messages_on_post_id"
   end
 


### PR DESCRIPTION
## Issue番号
#362 

## 予定時間/実績時間
4.0h / 7.5h 

## What - なにを修正したか？
- Messageテーブルにカラム「user_id」を追加
- コメント投稿時、コメント投稿者（ログインユーザID）をMessagesテーブル「user_id」に書込
- コメント表示時、アバター画像を表示する（Userテーブルを結合して取得する）
- ログインユーザのコメントのみ削除ボタンを表示する。
- 削除押下時、コメント削除を実行する。

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- コメント表示時、アバター画像を表示する（Userテーブルから取得する）
![スクリーンショット 2019-03-17 14 54 39](https://user-images.githubusercontent.com/40923242/54485934-9d381900-48c4-11e9-9819-84e158e0ebed.png)

- ログインユーザが投稿したコメントのみ削除ボタンを表示する。
![スクリーンショット 2019-03-17 14 56 15](https://user-images.githubusercontent.com/40923242/54485966-0029b000-48c5-11e9-83c1-a0a4e2c32b12.png)

- 削除押下時、コメント削除を実行する。
![スクリーンショット 2019-03-17 14 59 24](https://user-images.githubusercontent.com/40923242/54485999-6a425500-48c5-11e9-89ca-86f3882f63e3.png)
削除押下↓
![スクリーンショット 2019-03-17 14 59 32](https://user-images.githubusercontent.com/40923242/54486002-775f4400-48c5-11e9-8c7c-83c2c2d1e80f.png)
コメント削除される

## Why - なぜ修正したか？
匿名投稿防止（追跡可能にする）

<!-- 変更の目的 -->

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
