### PR TITLE
posts/index 表示順見直し

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -77,7 +77,7 @@ class PostsController < ApplicationController
 
     def search_posts
       posts = []
-      Post.order(created_at: "DESC").select() do |repo|
+      Post.order(status: "ASC", updated_at: "DESC").select() do |repo|
         client = GithubOss::GithubFetcher.new(repo.owner_and_repository)
         post = {
           "id" => repo.id,


### PR DESCRIPTION
## Issue番号
#374 

## 予定時間/実績時間
1.0h / 0.5h

## What - なにを修正したか？
表示順（①募集ステータス ②更新日付 の順番で表示）
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 募集停止前 （上に表示）
![スクリーンショット 2019-03-25 0 21 15](https://user-images.githubusercontent.com/40923242/54881527-4cac5700-4e94-11e9-8f6d-d4cd92deaa01.png)

- 募集停止後（下に表示）
![スクリーンショット 2019-03-25 0 22 00](https://user-images.githubusercontent.com/40923242/54881535-5f269080-4e94-11e9-87ff-dcf94a216014.png)

## Why - なぜ修正したか？
募集終了が４件続くと、スクロールが必要になるという指摘を受け、修正。
<!-- 変更の目的 -->

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
