### PR TITLE
Slackチャンネル名表示

### DIFF
--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -91,8 +91,8 @@ section#show-button
             | プロジェクト応募手順
           button.delete @click="isActive=!isActive"
         section.modal-card-body
-          p 1.下記URLよりMeister HackersのSlackに参加してください
+          p 1.下記URLよりMeister HackersのSlackに参加して下さい。
           a href="https://meister-hackers.slack.com/join/shared_invite/enQtNTYyMzAyNDM2MjI2LTAzYjIyYmY0ZWM5YWQ2ODc3M2Y4MGI3MWYxMTVmODk5NWU0NmNmMDc1NjVjMDBmODcxZDkyNjUwZTgxMTM0M2I" target="_blank" Slackに参加
-          p 2.募集ページに記載されたSlackチャンネルを検索してください
-          p 3.チャンネル内でプロジェクト投稿者とやりとりをしてください
+          p 2.このプロジェクトの連絡用チャンネル名は「#{@post.slack_channel}」です。
+          p 連絡用チャンネルに参加してプロジェクト投稿者と連絡を取って下さい。
         footer.modal-card-foot


### PR DESCRIPTION
## Issue番号
#376 

## 予定時間/実績時間
1.0h / 0.75h

## What - なにを修正したか？
参加ボタン押下時のポップアップにSlackチャンネル名を表示
<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
![スクリーンショット 2019-03-25 0 57 28](https://user-images.githubusercontent.com/40923242/54882073-a7947d00-4e99-11e9-8f1e-09b1c236b314.png)

## Why - なぜ修正したか？
現在のレイアウトだと、Slackチャンネル名が分からないため。

<!-- 変更の目的 -->

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
