### PR TITLE
未ログイン時のユーザ情報閲覧

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,4 +1,5 @@
-- set_meta_tags title: current_user.name
+- if user_signed_in?
+  - set_meta_tags title: current_user.name
 .inner
   div#mypage
     = javascript_pack_tag 'users/show.js'


### PR DESCRIPTION
## Issue番号
#402
## 予定時間/実績時間
0.5h / 0.5h
## What - なにを修正したか？

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->
- 未ログイン時
タイトルは、Meister Hackersのみ
アカウント名が少し中央揃えになる。（直し方が分からなかったです...すみません）
![スクリーンショット 2019-04-06 13 19 35](https://user-images.githubusercontent.com/40923242/55664804-48f2da00-586f-11e9-834e-c8716e78aefb.png)

- ログイン時
![スクリーンショット 2019-04-06 13 20 26](https://user-images.githubusercontent.com/40923242/55664783-ffa28a80-586e-11e9-8f0a-b1ff031828cd.png)

## Why - なぜ修正したか？
障害対応
<!-- 変更の目的 -->

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
